### PR TITLE
Fix casing of 'Djihad' to 'djihad' in subdomains

### DIFF
--- a/subdomains.json
+++ b/subdomains.json
@@ -6,7 +6,7 @@
   "lamari": { "type": "CNAME", "target": "8993646fba5bcc00.vercel-dns-017.com"},
   
   "_vercel": { "type": "TXT", "target": "vc-domain-verify=lamari.estin.pro,5b94ba9f13b4bb76c507"},
-    "Djihad": { "type": "CNAME", "target": "djihad-protofolio.onrender.com"}
+    "djihad": { "type": "CNAME", "target": "djihad-protofolio.onrender.com"}
 
   
 }


### PR DESCRIPTION
### Add subdomain for estin.pro

- Subdomain (only the prefix name): `yourname`
- Type: `CNAME` or `A`
- Target: `yoursite.example.com` or `1.2.3.4`

I confirm:
- I own the target or have permission to point to it.
- I followed naming rules: lowercase, letters/digits/hyphen, max 63 chars, no leading/trailing hyphen.

